### PR TITLE
tests/base32-unit-tests

### DIFF
--- a/__tests__/base32.test.ts
+++ b/__tests__/base32.test.ts
@@ -1,0 +1,74 @@
+import Base32, { Variant } from '@/Base32'
+
+const tests: ({
+	variant	: Variant
+	input	: string
+	output	: string
+})[] = [
+	{
+		variant	: 'RFC3548',
+		input	: 'some value',
+		output	: 'ONXW2ZJAOZQWY5LF',
+	},
+	{
+		variant	: 'RFC4648',
+		input	: 'some value',
+		output	: 'ONXW2ZJAOZQWY5LF',
+	},
+	{
+		variant	: 'RFC4648-HEX',
+		input	: 'some value',
+		output	: 'EDNMQP90EPGMOTB5',
+	},
+	{
+		variant	: 'Crockford',
+		input	: 'some value',
+		output	: 'EDQPTS90ESGPRXB5',
+	},
+]
+
+const clientSuffix = typeof window !== 'undefined' ? ' in the client' : ''
+
+
+describe( 'Base32.encode()', () => {
+	
+	tests.map( test => {
+
+		it( `encodes using ${ test.variant } variant` + clientSuffix, () => {
+			
+			const dataBuffer = (
+				typeof window !== 'undefined'
+					? new Uint8Array( new TextEncoder().encode( test.input ) )
+					: Buffer.from( test.input )
+			)
+	
+			expect( Base32.encode( dataBuffer, test.variant ) )
+				.toBe( test.output )
+
+		} )
+
+	} )
+
+} )
+
+
+describe( 'Base32.decode()', () => {
+	
+	tests.map( test => {
+
+		it( `decodes using ${ test.variant } variant` + clientSuffix, () => {
+
+			const decoded = Base32.decode( test.output, test.variant )
+			const converted = (
+				typeof window !== 'undefined'
+					? new TextDecoder().decode( decoded )
+					: Buffer.from( decoded ).toString()
+			)
+	
+			expect( converted ).toBe( test.input )
+
+		} )
+
+	} )
+
+} )

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
 		"test:ci:jsdom": "JSDOM=true pnpm test:ci",
 		"test:jest": "pnpm test jest.test.ts",
 		"test:jest:jsdom": "JSDOM=true pnpm test:jest",
+		"test:base32": "pnpm test base32.test.ts",
+		"test:base32:jsdom": "JSDOM=true pnpm test:base32",
 		"test:base64": "pnpm test base64.test.ts",
 		"test:base64:jsdom": "JSDOM=true pnpm test:base64"
 	},


### PR DESCRIPTION
- add `Base32.encode()` method tests
- add `Base32.decode()` method tests